### PR TITLE
Crystal Extension Shrine（精华祭坛 -> 水晶增生祭坛）

### DIFF
--- a/lang/zh_cn.json
+++ b/lang/zh_cn.json
@@ -502,7 +502,7 @@
   "block.aoa3.creeponia_portal": "蠕变传送门",
   "block.aoa3.creepy_banner": "苦力怕旗帜",
   "block.aoa3.crystal_banner": "晶体旗帜",
-  "block.aoa3.crystal_extension_shrine": "精华祭坛",
+  "block.aoa3.crystal_extension_shrine": "水晶增生祭坛",
   "block.aoa3.crystallised_rock": "晶化岩",
   "block.aoa3.crystallised_rock_slab": "晶化岩台阶",
   "block.aoa3.crystallised_rock_stairs": "晶化岩楼梯",


### PR DESCRIPTION
This shrine is no longer connected with "essence" in old AoA version, right?