### PR TITLE
bug fix

### DIFF
--- a/source/content/item/weapon/gun/BaseGun.java
+++ b/source/content/item/weapon/gun/BaseGun.java
@@ -55,6 +55,7 @@ public abstract class BaseGun extends Item {
 	protected final int firingDelay;
 	protected final float recoilMod;
 	protected double holsterMod;
+	protected int shellLevel = 0;
 
 	public BaseGun(Item.Properties properties, final double dmg, final int fireDelayTicks, final float recoilMod) {
 		super(properties);
@@ -135,6 +136,7 @@ public abstract class BaseGun extends Item {
 	@Override
 	public ActionResult<ItemStack> use(World world, PlayerEntity player, Hand hand) {
 		ItemStack stack = player.getItemInHand(hand);
+		this.shellLevel = EnchantmentHelper.getItemEnchantmentLevel(AoAEnchantments.SHELL.get(), stack);
 
 		if (hand != getGunHand(stack))
 			return ActionResult.fail(stack);
@@ -161,6 +163,7 @@ public abstract class BaseGun extends Item {
 	public void onUsingTick(ItemStack stack, LivingEntity shooter, int count) {
 		if (!isFullAutomatic() && count < getUseDuration(stack))
 			return;
+		this.shellLevel = EnchantmentHelper.getItemEnchantmentLevel(AoAEnchantments.SHELL.get(), stack);
 
 		ServerPlayerEntity player = shooter instanceof ServerPlayerEntity ? (ServerPlayerEntity)shooter : null;
 		int nextFireDelay = getFiringDelay();
@@ -229,7 +232,7 @@ public abstract class BaseGun extends Item {
 			float shellMod = 1;
 
 			if (bullet.getHand() != null)
-				shellMod += 0.1 * EnchantmentHelper.getItemEnchantmentLevel(AoAEnchantments.SHELL.get(), shooter.getItemInHand(bullet.getHand()));
+				shellMod += 0.1f * shellLevel;
 
 			if (DamageUtil.dealGunDamage(target, shooter, bullet, (float)getDamage() * bulletDmgMultiplier * shellMod)) {
 				doImpactEffect(target, shooter, bullet, bulletDmgMultiplier);


### PR DESCRIPTION
There is a bug about the SHELL enchantment damage of gun, and the steps to reproduce this bug are as follows:
1. Place a gun without SHELL enchantment in hotbar 1, and place a gun with SHELL enchantment in hotbar 2;
2. Switch to hotbar 2 immediately while shooting in hotbar 1;
3. The final damage comes from the gun of hotbar 2, but in reality it should be the gun in hotbar 1.

This bug is caused by [getting SHELL level with getItemInHand()](https://github.com/Tslat/Advent-Of-Ascension/blob/e97502da8bdd6081b6acc4635f03296d3e2e69a0/source/content/item/weapon/gun/BaseGun.java#L232), the result of getItemInHand() in step 2 is the gun in hotbar 2, although it should be the gun in hotbar 1.

So I changed the way of getting SHELL enchantment level to assigning the SHELL level to a member variable called [shellLevel](https://github.com/Sh1roCu/Advent-Of-Ascension/blob/4580746a4dc18ce97e4279f8ca9959f8bea76b7c/source/content/item/weapon/gun/BaseGun.java#L235) within [use()](https://github.com/Sh1roCu/Advent-Of-Ascension/blob/4580746a4dc18ce97e4279f8ca9959f8bea76b7c/source/content/item/weapon/gun/BaseGun.java#L139C3-L139C99) and [onUsingTick()](https://github.com/Sh1roCu/Advent-Of-Ascension/blob/4580746a4dc18ce97e4279f8ca9959f8bea76b7c/source/content/item/weapon/gun/BaseGun.java#L166).